### PR TITLE
Fix report modal height

### DIFF
--- a/static/css/partials/_modal-box.scss
+++ b/static/css/partials/_modal-box.scss
@@ -117,4 +117,8 @@
     #report-extra-info {
         margin: 10px 0;
     }
+    
+    #report-captcha {
+        min-height: 78px;
+    }
 }


### PR DESCRIPTION
The report dialog fails to set its height correctly due to the captcha loading. Setting a min-height fixes this.

![problem](https://i.imgur.com/SyUJHOR.png)
